### PR TITLE
Add sparse test

### DIFF
--- a/docs/joss/paper.md
+++ b/docs/joss/paper.md
@@ -90,7 +90,7 @@ We provide a basic hello world example here. Our implementation is well document
 Below is a notional interface; this is still in process for our development.
 -->
 ```python
-from pyotc.otc_backend.policy_iteration.sparse.exact import exact_otc
+from pyotc.otc_backend.policy_iteration.dense.exact import exact_otc
 import numpy as np
 
 P = np.array([[.5, .5], [.5, .5]])

--- a/src/pyotc/otc_backend/policy_iteration/sparse/exact.py
+++ b/src/pyotc/otc_backend/policy_iteration/sparse/exact.py
@@ -19,7 +19,13 @@ def exact_otc(Px, Py, c, stat_dist='best', max_iter=100):
     For a detailed discussion of the connection between the OTC problem and Markov Decision Processes (MDPs), see Section 4 of the paper.
     Additional background on policy iteration methods for solving average-cost MDP problems can be found in Chapters 8 and 9 of
     "Markov Decision Processes: Discrete Stochastic Dynamic Programming" by Martin L. Puterman.
-
+    
+    Note:
+        In the TCE step (implemented in exact_tce), we solve a block linear system using functions from scipy.sparse.linalg.
+        However, when A in Ax = b is nearly singular, we have observed a few cases where both SciPy solvers (scipy.sparse.linalg.spsolve, scipy.sparse.linalg.lsmr)
+        can produce results that differ from NumPy's solver (np.linalg.solve). This leads to discrepancies with the dense implementation and non-convergence. 
+        This is an issue with SciPy's sparse solvers and remains unresolved. The best approach in such cases is to use the dense implementation.
+        
     Args:
         Px (np.ndarray): Transition matrix of the source Markov chain of shape (dx, dx).
         Py (np.ndarray): Transition matrix of the target Markov chain of shape (dy, dy).

--- a/src/pyotc/otc_backend/policy_iteration/sparse/exact_tce.py
+++ b/src/pyotc/otc_backend/policy_iteration/sparse/exact_tce.py
@@ -52,14 +52,14 @@ def exact_tce(R_sparse, c):
     #     try:
     #         current_solution = sp.linalg.spsolve(A, rhs, permc_spec=spec)
     #         if not np.any(np.abs(current_solution) > 1e15):
-    #         print("spsolve successful with spec:", spec)
+    #             print("spsolve successful with spec:", spec)
     #             solution = current_solution
     #             break
     #         else:
     #             print(f"Solution with {spec} contains large values, trying next spec.")
     #     except ValueError as e:
     #         print(f"spsolve with {spec} encountered an error: trying next spec.")
-    #   if solution is None:
+    # if solution is None:
     #     raise RuntimeError("Failed to find a stable solution with any of the provided permc_specs for sp.linalg.spsolve solver.")
 
     # Solve the linear system using an iterative solver (lsmr)

--- a/src/pyotc/otc_backend/policy_iteration/sparse/exact_tce.py
+++ b/src/pyotc/otc_backend/policy_iteration/sparse/exact_tce.py
@@ -19,12 +19,18 @@ def exact_tce(R_sparse, c):
     an iterative solver (scipy.sparse.linalg.lsmr) is employed to efficiently handle large-scale sparse systems.
 
     Notes:
-        Solving Ax = b using a direct solver (sp.linalg.spsolve) on large networks resulted in:
+        1. When A in Ax = b is close to singular, we have observed few cases that both SciPy functions (scipy.sparse.linalg.spsolve, scipy.sparse.linalg.lsmr)
+        can produce results that differ from NumPy's solver, leading to different results with dense implementation and non-convergence. 
+        This is an issue with SciPy solvers and remains an unresolved issue. The best approach in such cases is to fall back to the dense implementation.
+
+        2. Solving Ax = b using a direct solver (scipy.sparse.linalg.spsolve) on large networks resulted in:
         "Not enough memory to perform factorization."
         This is likely due to excessive fill-in during LU factorization of the large sparse matrix.
         To address this, we switch to an iterative solver (scipy.sparse.linalg.lsmr),
         which is more memory-efficient and better suited for large-scale sparse systems.
 
+        3. To leave open the possibility of switching from 'lsmr' to 'spsolve', the corresponding 'spsolve' code has been retained as a commented-out block.
+   
     Args:
         R_sparse (scipy.sparse.csr_matrix): Sparse transition matrix of shape (dx*dy, dx*dy).
         c (np.ndarray): Cost vector of shape (dx, dy).

--- a/tests/benchmark/test_exact.py
+++ b/tests/benchmark/test_exact.py
@@ -102,9 +102,9 @@ edge_awareness_c = [c21, c23]
 
 def test_edge_awareness_exact_otc():
     # python optimal transport algo
-    exp_cost21_dense, _, _ = exact_otc_dense(edge_awareness_P[1], edge_awareness_P[0], edge_awareness_c[0])    
-    exp_cost23_dense, _, _ = exact_otc_dense(edge_awareness_P[1], edge_awareness_P[2], edge_awareness_c[1])
+    exp_cost21, _, _ = exact_otc_dense(edge_awareness_P[1], edge_awareness_P[0], edge_awareness_c[0])    
+    exp_cost23, _, _ = exact_otc_dense(edge_awareness_P[1], edge_awareness_P[2], edge_awareness_c[1])
     
     # check consistency
-    assert np.allclose(exp_cost21_dense, 0.5714285714285714)
-    assert np.allclose(exp_cost23_dense, 0.4464098659648351)
+    assert np.allclose(exp_cost21, 0.5714285714285714)
+    assert np.allclose(exp_cost23, 0.4464098659648351)

--- a/tests/benchmark/test_exact.py
+++ b/tests/benchmark/test_exact.py
@@ -6,7 +6,8 @@ import time
 import pytest
 
 from pyotc.otc_backend.policy_iteration.dense.exact import exact_otc_lp
-from pyotc.otc_backend.policy_iteration.dense.exact import exact_otc
+from pyotc.otc_backend.policy_iteration.dense.exact import exact_otc as exact_otc_dense
+from pyotc.otc_backend.policy_iteration.sparse.exact import exact_otc as exact_otc_sparse
 from pyotc.otc_backend.graph.utils import adj_to_trans, get_degree_cost
 from pyotc.examples.stochastic_block_model import stochastic_block_model
 from pyotc.examples.wheel import wheel_1, wheel_2, wheel_3
@@ -44,14 +45,21 @@ def test_sbm_exact_otc(transition, cost):
     end = time.time()
     print(f"`exact_otc` (scipy) run time: {end - start}")
 
-    # python optimal transport algo
+    # python optimal transport algo (numpy)
     start = time.time()
-    exp_cost2, _, _ = exact_otc(transition["P1"], transition["P2"], cost)
+    exp_cost2, _, _ = exact_otc_dense(transition["P1"], transition["P2"], cost)
+    end = time.time()
+    print(f"`exact_otc` (pot) run time: {end - start}")
+    
+    # python optimal transport algo (scipy.sparse)
+    start = time.time()
+    exp_cost3, _, _ = exact_otc_sparse(transition["P1"], transition["P2"], cost)
     end = time.time()
     print(f"`exact_otc` (pot) run time: {end - start}")
 
     # check consistency
     assert np.allclose(exp_cost1, exp_cost2)
+    assert np.allclose(exp_cost1, exp_cost3)
 
 
 # 2. Test exact OTC on wheel graph
@@ -69,16 +77,17 @@ wheel_c = [
 
 def test_wheel_exact_otc():
     # python optimal transport algo
-    start = time.time()
-    exp_cost12, _, _ = exact_otc(wheel_P[0], wheel_P[1], wheel_c[0])
-    exp_cost13, _, _ = exact_otc(wheel_P[0], wheel_P[2], wheel_c[1])
-    end = time.time()
-    print(f"`exact_otc` (pot) run time: {end - start}")
+    exp_cost12_dense, _, _ = exact_otc_dense(wheel_P[0], wheel_P[1], wheel_c[0])
+    exp_cost12_sparse, _, _ = exact_otc_sparse(wheel_P[0], wheel_P[1], wheel_c[0])
+    
+    exp_cost13_dense, _, _ = exact_otc_dense(wheel_P[0], wheel_P[2], wheel_c[1])
+    exp_cost13_sparse, _, _ = exact_otc_sparse(wheel_P[0], wheel_P[2], wheel_c[1])
 
     # check consistency
-    print(exp_cost12, exp_cost13)
-    assert np.allclose(exp_cost12, 2.6551724137931036)
-    assert np.allclose(exp_cost13, 2.551724137931033)
+    assert np.allclose(exp_cost12_dense, 2.6551724137931036)
+    assert np.allclose(exp_cost12_dense, exp_cost12_sparse)
+    assert np.allclose(exp_cost13_dense, 2.551724137931033)
+    assert np.allclose(exp_cost13_dense, exp_cost13_sparse)
 
 
 # 3. Test exact OTC on edge awareness example
@@ -93,17 +102,9 @@ edge_awareness_c = [c21, c23]
 
 def test_edge_awareness_exact_otc():
     # python optimal transport algo
-    start = time.time()
-    exp_cost21, _, _ = exact_otc(
-        edge_awareness_P[1], edge_awareness_P[0], edge_awareness_c[0]
-    )
-    exp_cost23, _, _ = exact_otc(
-        edge_awareness_P[1], edge_awareness_P[2], edge_awareness_c[1]
-    )
-    end = time.time()
-    print(f"`exact_otc` (pot) run time: {end - start}")
-
+    exp_cost21_dense, _, _ = exact_otc_dense(edge_awareness_P[1], edge_awareness_P[0], edge_awareness_c[0])    
+    exp_cost23_dense, _, _ = exact_otc_dense(edge_awareness_P[1], edge_awareness_P[2], edge_awareness_c[1])
+    
     # check consistency
-    print(exp_cost21, exp_cost23)
-    assert np.allclose(exp_cost21, 0.5714285714285714)
-    assert np.allclose(exp_cost23, 0.4464098659648351)
+    assert np.allclose(exp_cost21_dense, 0.5714285714285714)
+    assert np.allclose(exp_cost23_dense, 0.4464098659648351)


### PR DESCRIPTION
This PR adds tests for the sparse implementations of OTC.

As Yuning pointed out, I observed a few cases where the sparse implementation fails to converge, while the dense implementation converges. The issue arises in the `exact_tce` step, where we need to solve Ax=b. In the dense case, this is handled by `np.linalg.solve`, but in the sparse case, we must rely on `scipy.sparse.linalg.lsmr` or `scipy.sparse.linalg.spsolve`. However, when A is close to singular, these SciPy functions can produce results that differ from NumPy’s solver, leading to non-convergence. Since this behavior is beyond what we can reasonably fix, the best approach in such cases is to fall back to the dense implementation.