### PR TITLE
Fix codecov coverage

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -26,4 +26,3 @@ def tests(session):
     session.install("-e", ".")
     session.install("pytest", "pytest-cov")
     session.run("pytest", "--cov=pyotc", "--cov-report=term", "--cov-report=xml")
-


### PR DESCRIPTION
Changed `session.install(".")` to `session.install("-e", ".")` to install the package in editable mode.

This led to an increase in coverage from 0 to 77.


https://github.com/pyotc/pyotc/actions/runs/21386250766/job/61563173154

<img width="723" height="723" alt="image" src="https://github.com/user-attachments/assets/100df82a-8ff8-44c2-a951-62e14c68a838" />
