### PR TITLE
update notebook to use public api

### DIFF
--- a/docs/joss/paper.md
+++ b/docs/joss/paper.md
@@ -90,7 +90,7 @@ We provide a basic hello world example here. Our implementation is well document
 Below is a notional interface; this is still in process for our development.
 -->
 ```python
-from pyotc.otc_backend.policy_iteration.dense.exact import exact_otc
+from pyotc import exact_otc
 import numpy as np
 
 P = np.array([[.5, .5], [.5, .5]])

--- a/notebooks/Sparse.ipynb
+++ b/notebooks/Sparse.ipynb
@@ -73,12 +73,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import sys\n",
-    "import os\n",
     "\n",
-    "sys.path.append(os.path.abspath(\"../src\"))\n",
-    "\n",
-    "from pyotc.otc_backend.policy_iteration.sparse.exact import exact_otc\n",
+    "from pyotc import exact_otc\n",
     "from pyotc.otc_backend.graph.utils import adj_to_trans, get_degree_cost\n",
     "from pyotc.examples.stochastic_block_model import stochastic_block_model"
    ]
@@ -163,9 +159,9 @@
       "Computing exact TCE...\n",
       "Computing exact TCI...\n",
       "Convergence reached in 5 iterations. Computing stationary distribution...\n",
-      "[exact_otc] Finished. Total time elapsed: 10.326 seconds.\n",
+      "[exact_otc] Finished. Total time elapsed: 9.503 seconds.\n",
       "\n",
-      "Exact OTC cost between SBM1 and SBM2: 0.9336440288840459\n"
+      "Exact OTC cost between SBM1 and SBM2: 0.9336439995313762\n"
      ]
     }
    ],
@@ -178,7 +174,7 @@
     "c = get_degree_cost(A1, A2)\n",
     "\n",
     "# Run Exact OTC using the sparse implementation\n",
-    "exp_cost, R, stat_dist = exact_otc(P1, P2, c, stat_dist=\"best\")\n",
+    "exp_cost, R, stat_dist = exact_otc(P1, P2, c, stat_dist=\"best\", backend=\"sparse\")\n",
     "print(\"\\nExact OTC cost between SBM1 and SBM2:\", exp_cost)"
    ]
   }

--- a/notebooks/pyotc_demo.ipynb
+++ b/notebooks/pyotc_demo.ipynb
@@ -38,12 +38,8 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import networkx as nx\n",
-    "import sys\n",
-    "import os\n",
     "\n",
-    "sys.path.append(os.path.abspath(\"../src\"))\n",
-    "\n",
-    "from pyotc.otc_backend.policy_iteration.dense.exact import exact_otc\n",
+    "from pyotc import exact_otc\n",
     "from pyotc.otc_backend.graph.utils import adj_to_trans, get_degree_cost\n",
     "from pyotc.examples.stochastic_block_model import stochastic_block_model"
    ]
@@ -218,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With the two transition matrices $P1, P2$ and the cost matrix $c$, we can now solve the Optimal Transition Coupling (OTC) problem.\n",
+    "With the two transition matrices $P_1, P_2$ and the cost matrix $c$, we can now solve the Optimal Transition Coupling (OTC) problem.\n",
     "\n",
     "The goal is to find a transition coupling between the two Markov chains that minimizes the expected cost.\n",
     "This is done using the `exact_otc()` function in `pyotc`, which returns the optimal cost and optimal transition coupling.\n",
@@ -228,16 +224,17 @@
     "\n",
     "The `exact_otc` function takes five inputs:\n",
     "\n",
-    "- `Px` and `Py`: two transition matrices\n",
+    "- `P1` and `P2`: two transition matrices\n",
     "- `c`: cost function\n",
     "- `stat_dist` (optional): method for computing the stationary distribution (default: `best`)\n",
-    "- `max_iter` (optional): maximum number of iterations for convergence (default: 100)\n",
+    "- `backend` (optional): `dense` or `sparse` (default: `dense`)\n",
     "\n",
-    "Below, we provide a brief overview of the `stat_dist` and `max_iter` parameters.\n",
+    "Below, we provide a brief overview of the `stat_dist` and `backend` parameters.\n",
     "\n",
-    "`max_iter`    \n",
+    "`backend`    \n",
     "\n",
-    "Sets the maximum number of iterations for convergence in computing the transition coupling. In practice, `exact_otc` usually converges within about 10 iterations, so the default value of 100 is typically sufficient.\n",
+    "In the TCE step (implemented in exact_tce), we solve a block linear system. This can be solved using functions from np.linalg.solve (`dense`) or scipy.sparse.linalg (`sparse`). We recommend using `sparse` for large networks.\n",
+    "\n",
     "\n",
     "`stat_dist`  \n",
     "\n",
@@ -267,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -294,14 +291,56 @@
       "Computing exact TCE...\n",
       "Computing exact TCI...\n",
       "Convergence reached in 6 iterations. Computing stationary distribution...\n",
-      "[exact_otc] Finished. Total time elapsed: 1.173 seconds.\n",
+      "[exact_otc] Finished. Total time elapsed: 1.023 seconds.\n",
       "\n",
-      "Exact OTC cost between SBM1 and SBM2: 0.7000538762516204\n"
+      "Exact OTC cost between SBM1 and SBM2: 0.7000538762516151\n"
      ]
     }
    ],
    "source": [
+    "# Compute exact OTC (dense backend)\n",
     "exp_cost, R, stat_dist = exact_otc(P1, P2, c, stat_dist=\"best\")\n",
+    "print(\"\\nExact OTC cost between SBM1 and SBM2:\", exp_cost)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting exact_otc_sparse...\n",
+      "Iteration: 0\n",
+      "Computing exact TCE...\n",
+      "Computing exact TCI...\n",
+      "Iteration: 1\n",
+      "Computing exact TCE...\n",
+      "Computing exact TCI...\n",
+      "Iteration: 2\n",
+      "Computing exact TCE...\n",
+      "Computing exact TCI...\n",
+      "Iteration: 3\n",
+      "Computing exact TCE...\n",
+      "Computing exact TCI...\n",
+      "Iteration: 4\n",
+      "Computing exact TCE...\n",
+      "Computing exact TCI...\n",
+      "Iteration: 5\n",
+      "Computing exact TCE...\n",
+      "Computing exact TCI...\n",
+      "Convergence reached in 6 iterations. Computing stationary distribution...\n",
+      "[exact_otc] Finished. Total time elapsed: 1.847 seconds.\n",
+      "\n",
+      "Exact OTC cost between SBM1 and SBM2: 0.7000539112573221\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute exact OTC (sparse backend)\n",
+    "exp_cost, R, stat_dist = exact_otc(P1, P2, c, stat_dist=\"best\", backend=\"sparse\")\n",
     "print(\"\\nExact OTC cost between SBM1 and SBM2:\", exp_cost)"
    ]
   },


### PR DESCRIPTION
Refactors how the `exact_otc` function is imported and used across documentation and demo notebooks, and improves the clarity of the API documentation for `exact_otc`. It also adds explicit examples of using both dense and sparse backends.