### PR TITLE
Stat dist requires c

### DIFF
--- a/src/pyotc/otc_backend/policy_iteration/utils.py
+++ b/src/pyotc/otc_backend/policy_iteration/utils.py
@@ -33,7 +33,7 @@ def get_best_stat_dist(P, c):
     return stat_dist, exp_cost
 
 
-def get_stat_dist(P, c, method="best"):
+def get_stat_dist(P, method="best", c=None):
     """
     Computes the stationary distribution of a Markov chain given its transition matrix P.
 
@@ -44,14 +44,17 @@ def get_stat_dist(P, c, method="best"):
 
     Args:
         P (np.ndarray): Transition matrix of the Markov chain, shape (n, n).
-        c (np.ndarray): Cost vector of shape (n,).
         method (str): Method used to compute the stationary distribution.
                       One of 'eigen', 'iterative', or 'best'. Defaults to 'best'.
+        c (np.ndarray): Cost vector of shape (n,).
 
     Returns:
         pi (np.ndarray): Stationary distribution vector of shape (n,), summing to 1.
         exp_cost (float): Expected cost under the stationary distribution.
     """
+    if c is None:
+        raise ValueError("Cost function 'c' is required.")
+
     if method == "best":
         # 'best' method minimizes expected cost under stationary constraints
         n = P.shape[0]

--- a/src/pyotc/otc_backend/policy_iteration/utils.py
+++ b/src/pyotc/otc_backend/policy_iteration/utils.py
@@ -33,7 +33,7 @@ def get_best_stat_dist(P, c):
     return stat_dist, exp_cost
 
 
-def get_stat_dist(P, method="best", c=None):
+def get_stat_dist(P, c, method="best"):
     """
     Computes the stationary distribution of a Markov chain given its transition matrix P.
 
@@ -44,23 +44,16 @@ def get_stat_dist(P, method="best", c=None):
 
     Args:
         P (np.ndarray): Transition matrix of the Markov chain, shape (n, n).
+        c (np.ndarray): Cost vector of shape (n,).
         method (str): Method used to compute the stationary distribution.
                       One of 'eigen', 'iterative', or 'best'. Defaults to 'best'.
-        c (np.ndarray, optional): Cost vector of shape (n,) used only when method='best'.
 
     Returns:
         pi (np.ndarray): Stationary distribution vector of shape (n,), summing to 1.
-        exp_cost (float or None): Expected cost under the stationary distribution if method='best', else None.
-
-    Raises:
-        ValueError: If method is 'best' but cost vector `c` is not provided,
-                    or if an invalid method name is given.
+        exp_cost (float): Expected cost under the stationary distribution.
     """
     if method == "best":
         # 'best' method minimizes expected cost under stationary constraints
-        if c is None:
-            raise ValueError("Cost function 'c' is required when method='best'.")
-
         n = P.shape[0]
         c = np.reshape(c, (n, -1))
 

--- a/tests/benchmark/test_exact.py
+++ b/tests/benchmark/test_exact.py
@@ -134,3 +134,13 @@ def test_exact_otc_invalid_backend():
             edge_awareness_c[1],
             backend="invalid_backend",
         )
+
+
+def test_exact_otc_missing_cost():
+    with pytest.raises(ValueError):
+        exact_otc(
+            edge_awareness_P[1],
+            edge_awareness_P[2],
+            None,
+            backend="dense",
+        )

--- a/tests/benchmark/test_exact.py
+++ b/tests/benchmark/test_exact.py
@@ -139,8 +139,4 @@ def test_exact_otc_invalid_backend():
 
 def test_get_stat_dist_missing_cost():
     with pytest.raises(ValueError):
-        get_stat_dist(
-            edge_awareness_P[1],
-            method="best",
-            c=None
-        )
+        get_stat_dist(edge_awareness_P[1], method="best", c=None)

--- a/tests/benchmark/test_exact.py
+++ b/tests/benchmark/test_exact.py
@@ -11,6 +11,7 @@ from pyotc.otc_backend.graph.utils import adj_to_trans, get_degree_cost
 from pyotc.examples.stochastic_block_model import stochastic_block_model
 from pyotc.examples.wheel import wheel_1, wheel_2, wheel_3
 from pyotc.examples.edge_awareness import graph_1, graph_2, graph_3, c21, c23
+from pyotc.otc_backend.policy_iteration.utils import get_stat_dist
 
 # 1. Test exact OTC on stochastic block model
 np.random.seed(100)
@@ -136,11 +137,10 @@ def test_exact_otc_invalid_backend():
         )
 
 
-def test_exact_otc_missing_cost():
+def test_get_stat_dist_missing_cost():
     with pytest.raises(ValueError):
-        exact_otc(
+        get_stat_dist(
             edge_awareness_P[1],
-            edge_awareness_P[2],
-            None,
-            backend="dense",
+            method="best",
+            c=None
         )


### PR DESCRIPTION
This pull request improves error handling in the `get_stat_dist` utility and adds a corresponding test to ensure correct behavior when required arguments are missing. 

* Updated `get_stat_dist` in `utils.py` to always require the `c` cost vector, raising a `ValueError` if it is not provided, regardless of the method used. The error message and logic have been clarified.
* Added a new test, `test_get_stat_dist_missing_cost`, in `test_exact.py` to verify that a `ValueError` is raised when `get_stat_dist` is called without a cost vector.