### PR TITLE
Bump version to 040

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [0.4.0] - 2026-06-22
+* Fix `get_stat_dist` to always require the cost vector `c`
+* Revise JOSS draft for final submission:
+  * Add benchmark matrix and MATLAB details
+  * Fix bibliography errors and a broken link in `CONTRIBUTING.md`
+  * Remove outdated comments from `paper.md`
+  * Fix typos and add authors' ORCID IDs
+
+## [0.3.3] - 2026-04-07
+* Fix minor test error after release
+
+## [0.3.2] - 2026-04-07
+* Update draft to match the new JOSS format
+* Align OTC return value with corresponding stationary distributions
 
 ## [0.3.1] - 2026-02-13
 * Update Sphinx documentation theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyotc"
-version = "0.3.3"
+version = "0.4.0"
 authors = [
     {name="Jay Hineman"},
     {name="Yuning Pan"},


### PR DESCRIPTION
This pull request prepares the project for the 0.4.0 release, updating the version and documenting recent changes. The main focus is on finalizing the JOSS (Journal of Open Source Software) draft and ensuring all recent fixes and improvements are clearly recorded.

Release and documentation updates:

* Bump project version to `0.4.0` in `pyproject.toml` to mark the new release.
* Add a new `0.4.0` section to `CHANGELOG.md`, summarizing key updates: enforcing the requirement of the cost vector `c` in `get_stat_dist`, revising the JOSS draft (adding benchmark matrix, MATLAB details, bibliography and link fixes, comment removals, typo corrections, and adding ORCID IDs).
* Add entries for previous patch releases (`0.3.2` and `0.3.3`) to `CHANGELOG.md` for completeness.